### PR TITLE
fix: more idempotency

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,18 +1,20 @@
 {
   "version": "0.2.0",
   "configurations": [
-      {
-          "type": "node",
-          "request": "launch",
-          "name": "Execute Command",
-          "skipFiles": [
-              "<node_internals>/**"
-          ],
-          "program": "${workspaceFolder}/bin/dev.js",
-          "args": [
-            "hello",
-            "world",
-          ],
-      }
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach",
+      "port": 9229,
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Execute Command",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/bin/dev.js",
+      "args": ["hello", "world"]
+    }
   ]
 }


### PR DESCRIPTION
don't do things if they're already done because it causes errors
- file renames
- adding items to ignore files

also, dev-scripts bring in dev-config so it shouldn't be added by the script.